### PR TITLE
Add cli actions

### DIFF
--- a/pennylane_orquestra/cli_actions.py
+++ b/pennylane_orquestra/cli_actions.py
@@ -42,7 +42,8 @@ def qe_get(workflow_id, option="workflow"):
             Examples include ``workflow`` and ``workflowresult``.
 
     Returns:
-        str: response message of the CLI call
+        list: the list of strings representing the response message of the CLI
+        call
     """
     process = subprocess.Popen(
         ["qe", "get", option, str(workflow_id)], stdout=subprocess.PIPE, universal_newlines=True
@@ -102,7 +103,8 @@ def workflow_details(workflow_id):
             retrieved
 
     Returns:
-        str: response message of the CLI call
+        list: the list of strings representing the response message of the CLI
+        call
     """
     return qe_get(workflow_id, option="workflow")
 
@@ -119,7 +121,8 @@ def workflow_results(workflow_id):
             Examples include ``workflow`` and ``workflowresult``.
 
     Returns:
-        str: response message of the CLI call
+        list: the list of strings representing the response message of the CLI
+        call
     """
     return qe_get(workflow_id, option="workflowresult")
 

--- a/pennylane_orquestra/cli_actions.py
+++ b/pennylane_orquestra/cli_actions.py
@@ -218,6 +218,8 @@ def loop_until_finished(workflow_id, timeout=300):
     # Setting filename=None will treat the file as temporary and it will be
     # removed
     file_tmp = urllib.request.urlretrieve(location, filename=None)[0]
+
+    # Data is retrieved as a tarball, need to extract the json file within
     if tarfile.is_tarfile(file_tmp):
         tar = tarfile.open(file_tmp, "r:gz")
         tar.extractall()

--- a/pennylane_orquestra/cli_actions.py
+++ b/pennylane_orquestra/cli_actions.py
@@ -1,3 +1,17 @@
+# Copyright 2020 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 This module contains utilities and auxiliary functions for using the Orquestra
 Quantum Engine command line interface (CLI).

--- a/pennylane_orquestra/cli_actions.py
+++ b/pennylane_orquestra/cli_actions.py
@@ -16,12 +16,12 @@
 This module contains utilities and auxiliary functions for using the Orquestra
 Quantum Engine command line interface (CLI).
 """
-import subprocess
-import time
-import os
-import urllib.request
 import json
+import os
+import subprocess
 import tarfile
+import time
+import urllib.request
 
 import yaml
 from appdirs import user_data_dir

--- a/pennylane_orquestra/cli_actions.py
+++ b/pennylane_orquestra/cli_actions.py
@@ -215,7 +215,7 @@ def loop_until_finished(workflow_id, timeout=300):
             continue
 
     # 3. Obtain the data from the URL
-    # Seting filename=None will treat the file as temporary and it will be
+    # Setting filename=None will treat the file as temporary and it will be
     # removed
     file_tmp = urllib.request.urlretrieve(location, filename=None)[0]
     if tarfile.is_tarfile(file_tmp):

--- a/pennylane_orquestra/cli_actions.py
+++ b/pennylane_orquestra/cli_actions.py
@@ -222,7 +222,7 @@ def loop_until_finished(workflow_id, timeout=300):
     # removed
     file_tmp = urllib.request.urlretrieve(location, filename=None)[0]
 
-    # Data is retrieved as a tarball, need to extract the json file within
+    # Data is retrieved as a tarfile, need to extract the json file within
     if tarfile.is_tarfile(file_tmp):
         tar = tarfile.open(file_tmp, "r:gz")
         tar.extractall()
@@ -230,5 +230,7 @@ def loop_until_finished(workflow_id, timeout=300):
 
         with open("workflow_result.json") as json_file:
             data = json.load(json_file)
+    else:
+        raise ValueError(f"Unexpected datatype for the retrieved result: not a tarfile.")
 
     return data

--- a/pennylane_orquestra/cli_actions.py
+++ b/pennylane_orquestra/cli_actions.py
@@ -131,7 +131,7 @@ def write_workflow_file(filename, workflow):
     """Write a workflow file given the name of the file.
 
     This function will create a YAML file with the workflow content. The file
-    is placed into a user specific data folder specified by using
+    is placed into a user-specific data folder specified by using
     ``appdirs.user_data_dir``.
 
     Args:

--- a/pennylane_orquestra/cli_actions.py
+++ b/pennylane_orquestra/cli_actions.py
@@ -170,6 +170,11 @@ def loop_until_finished(workflow_id, timeout=300):
 
     Returns:
         dict: the resulting dictionary parsed from a json file
+
+    Raises:
+        TimeoutError: if no response was obtained after the timeout
+        ValueError: if the workflow execution failed or if the result was not
+        returned as a tarfile
     """
     start = time.time()
     query_results = True

--- a/pennylane_orquestra/cli_actions.py
+++ b/pennylane_orquestra/cli_actions.py
@@ -1,0 +1,215 @@
+"""
+This module contains utilities and auxiliary functions for using the Orquestra
+Quantum Engine command line interface (CLI).
+"""
+import subprocess
+import time
+import os
+import urllib.request
+import json
+import tarfile
+
+import yaml
+from appdirs import user_data_dir
+
+
+def qe_get(workflow_id, option="workflow"):
+    """Function for getting information via an Orquestra Quantum Engine CLI
+    call.
+
+    This function is mostly used for retrieving workflow related information.
+
+    Args:
+        workflow_id (str): the workflow id for which information will be
+            retrieved
+
+    Kwargs:
+        option (str): The option specified for the ``qe get`` CLI call.
+            Examples include ``workflow`` and ``workflowresult``.
+
+    Returns:
+        str: response message of the CLI call
+    """
+    process = subprocess.Popen(
+        ["qe", "get", option, str(workflow_id)], stdout=subprocess.PIPE, universal_newlines=True
+    )
+    return process.stdout.readlines()
+
+
+def qe_submit(filepath, keep_file=False):
+    """Function for submitting a workflow via a CLI call.
+
+    Handling submission response messages was based on using Orquestra API
+    v1.0.0.
+
+    Args:
+        filepath (str): the filepath for the workflow file
+
+    Keyword Args:
+        keep_file=False (bool): whether or not to keep or delete the workflow
+            file after submission
+
+    Returns:
+        str: the ID of the workflow submitted
+
+    Raises:
+        ValueError: if the submission was not successful
+    """
+    process = subprocess.Popen(
+        ["qe", "submit", "workflow", str(filepath)], stdout=subprocess.PIPE, universal_newlines=True
+    )
+    res = process.stdout.readlines()
+
+    details = "".join(res)
+    if "Success" not in details:
+        raise ValueError(res)
+
+    if not keep_file:
+        os.remove(filepath)
+
+    unexpected_resp_msg = "Received an unexpected response after submitting workflow."
+    if isinstance(res, list):
+        try:
+            # Get the workflow ID after submitting a workflow
+            workflow_id = res[1].split()[-1]
+        except IndexError as e:
+            raise ValueError(unexpected_resp_msg) from e
+    else:
+        raise ValueError(unexpected_resp_msg)
+
+    return workflow_id
+
+
+def workflow_details(workflow_id):
+    """Function for getting workflow details via a CLI call.
+
+    Args:
+        workflow_id (str): the workflow id for which information will be
+            retrieved
+
+    Returns:
+        str: response message of the CLI call
+    """
+    return qe_get(workflow_id, option="workflow")
+
+
+def workflow_results(workflow_id):
+    """Function for getting workflow results via a CLI call.
+
+    Args:
+        workflow_id (str): the workflow id for which information will be
+            retrieved
+
+    Kwargs:
+        option (str): The option specified for the ``qe get`` CLI call.
+            Examples include ``workflow`` and ``workflowresult``.
+
+    Returns:
+        str: response message of the CLI call
+    """
+    return qe_get(workflow_id, option="workflowresult")
+
+
+def write_workflow_file(filename, workflow):
+    """Write a workflow file given the name of the file.
+
+    This function will create a YAML file with the workflow content. The file
+    is placed into a user specific data folder specified by using
+    ``appdirs.user_data_dir``.
+
+    Args:
+        filename (str): the name of the file to write
+        workflow (dict): the workflow generated as a dictionary
+    """
+    # Get the directory to write the file to
+    directory = user_data_dir("pennylane-orquestra", "Xanadu")
+
+    # Create target Directory if it doesn't exist
+    os.makedirs(directory, exist_ok=True)
+
+    filepath = os.path.join(directory, filename)
+
+    with open(filepath, "w") as file:
+        # The order of the keys within the YAML file is pre-defined for Orquestra,
+        # hence need to keep the order
+        yaml.dump(workflow, file, sort_keys=False)
+
+    return filepath
+
+
+def loop_until_finished(workflow_id, timeout=300):
+    """Loops until the workflow execution has finished by querying workflow
+    details using the workflow ID.
+
+    The flows of messages and the checks were based on responses obtained when
+    using Orquestra API v1.0.0.
+
+    Args:
+        workflow_id (str): the ID of the workflow for which to return the
+            results
+
+    Keyword args:
+        timeout (int): seconds to wait until raising a TimeoutError
+
+    Returns:
+        dict: the resulting dictionary parsed from a json file
+    """
+    start = time.time()
+    query_results = True
+    tries = 0
+    while query_results:
+        tries += 1
+
+        # Check if we've exceeded the timeout time, otherwise loop further
+        if time.time() - start > timeout:
+            current_status = workflow_details(workflow_id)
+            raise TimeoutError(
+                f"The workflow results for workflow "
+                f"{workflow_id} were not obtained after {timeout/60} minutes. "
+                f"{current_status}"
+            )
+
+        if tries % 20 == 0:
+
+            # Check if the status shows that the workflow failed, after a
+            # certain number of tries
+            status = workflow_details(workflow_id)
+            details_string = "".join(status).split()
+            if "Failed" in details_string:
+                raise ValueError(f"Something went wrong with executing the workflow. {status}")
+
+        results = workflow_results(workflow_id)
+
+        # 1. Attempt to extract a location
+        try:
+            # Assume that the second line of the message contains the URL
+            location = results[1].split()[1]
+        except IndexError:
+            # The format of the results were not like the message with URL
+            continue
+
+        # 2. Check that the location is a valid URL
+        try:
+
+            # We expect that this fails if an invalid URL location was outputted
+            urllib.request.urlopen(location)
+
+            # If we managed to get the URL, we can stop querying
+            query_results = False
+
+        except urllib.error.URLError:
+            continue
+
+    # 3. Obtain the data from the URL
+    # Seting filename=None will treat the file as temporary and it will be
+    # removed
+    file_tmp = urllib.request.urlretrieve(location, filename=None)[0]
+    if tarfile.is_tarfile(file_tmp):
+        tar = tarfile.open(file_tmp, "r:gz")
+        tar.extractall()
+        tar.close()
+
+        with open("workflow_result.json") as json_file:
+            data = json.load(json_file)
+
+    return data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,40 @@ import pennylane as qml
 from copy import deepcopy
 
 
+# Auxiliary classes and functions
+def qe_list_workflow():
+    """Function for a CLI call to list workflows.
+
+    This CLI call needs the caller to be logged in to Orquestra. It is an
+    inexpensive way of checking that the caller has been authenticated with the
+    Orquestra platform.
+    """
+    process = subprocess.Popen(
+        ["qe", "list", "workflow"], stdout=subprocess.PIPE, universal_newlines=True
+    )
+    return process.stdout.readlines()
+
+
+class MockPopen:
+    """A mock class that allows to mock the self.stdout.readlines() call."""
+
+    def __init__(self, msg=None):
+        class MockStdOut:
+            def __init__(self, msg):
+                self.msg = msg
+
+            def readlines(self, *args):
+                if self.msg is None:
+                    self.msg = [
+                        "Successfully submitted workflow to quantum engine!\n",
+                        "SomeWorkflowID",
+                    ]
+                return self.msg
+
+        self.stdout = MockStdOut(msg)
+
+
+
 # Auxiliary data
 
 # Default data that are inserted into a workflow template

--- a/tests/test_cli_actions.py
+++ b/tests/test_cli_actions.py
@@ -177,17 +177,17 @@ class TestCLIFunctions:
 
         # Change to the test directory
         os.chdir(tmpdir)
-        with pytest.raises(ValueError, match="not a tarfile"):
-            with monkeypatch.context() as m:
-                result_message = ["Some message2", "Some location"]
+        with monkeypatch.context() as m:
+            result_message = ["Some message2", "Some location"]
 
-                m.setattr(
-                    pennylane_orquestra.cli_actions, "workflow_results", lambda *args: result_message
-                )
-                m.setattr(urllib.request, "urlopen", lambda arg: arg)
+            m.setattr(
+                pennylane_orquestra.cli_actions, "workflow_results", lambda *args: result_message
+            )
+            m.setattr(urllib.request, "urlopen", lambda arg: arg)
 
-                # test_file is a json file instead of a tarfile
-                m.setattr(urllib.request, "urlretrieve", lambda *args, **kwargs: (test_file,))
+            # test_file is a json file instead of a tarfile
+            m.setattr(urllib.request, "urlretrieve", lambda *args, **kwargs: (test_file,))
+            with pytest.raises(ValueError, match="not a tarfile"):
                 loop_until_finished("Some ID", timeout=1)
 
     # Expected to fail if qe is unavailable (for example for the CI)

--- a/tests/test_cli_actions.py
+++ b/tests/test_cli_actions.py
@@ -190,7 +190,7 @@ class TestCLIFunctions:
                 m.setattr(urllib.request, "urlretrieve", lambda *args, **kwargs: (test_file,))
                 loop_until_finished("Some ID", timeout=1)
 
-    # Expected to fail if qe is unavailable
+    # Expected to fail if qe is unavailable (for example for the CI)
     @pytest.mark.xfail(raises=FileNotFoundError)
     def test_invalid_url_loop_till_timeout(self, monkeypatch):
         """Test that when receiving an invalid url, looping continues until the

--- a/tests/test_cli_actions.py
+++ b/tests/test_cli_actions.py
@@ -161,6 +161,8 @@ class TestCLIFunctions:
             m.setattr(urllib.request, "urlretrieve", lambda *args, **kwargs: (test_tar,))
             assert loop_until_finished("Some ID", timeout=1) == decoded_data
 
+    # Expected to fail if qe is unavailable
+    @pytest.mark.xfail(raises=RuntimeError)
     def test_invalid_url_loop_till_timeout(self, monkeypatch):
         """Test that when receiving an invalid url, looping continues until the
         timeout."""

--- a/tests/test_cli_actions.py
+++ b/tests/test_cli_actions.py
@@ -1,0 +1,187 @@
+"""
+Unit tests for the ```cli_actions`` module, without sending any requests to
+Orquestra.
+"""
+import pytest
+import subprocess
+import tarfile
+import os
+import urllib.request
+import json
+
+import yaml
+import pennylane_orquestra.gen_workflow as gw
+import pennylane_orquestra
+from pennylane_orquestra.cli_actions import qe_submit, write_workflow_file, loop_until_finished
+
+from conftest import backend_specs_default, qasm_circuit_default, operator_string_default, MockPopen
+
+
+class TestCLIFunctions:
+    """Test functions for CLI actions work as expected."""
+
+    def test_submit_raises_no_success(self, monkeypatch):
+        """Test that the qe_submit method raises an error if not a successful
+        message was received."""
+
+        no_success_msg = "Not a success message."
+        with monkeypatch.context() as m:
+            # Disable submitting to the Orquestra platform by mocking Popen
+            m.setattr(subprocess, "Popen", lambda *args, **kwargs: MockPopen(no_success_msg))
+
+            with pytest.raises(ValueError, match=no_success_msg):
+                workflow_id = qe_submit("some_filename")
+
+    @pytest.mark.parametrize("response", [["Test Success"], "Test Success"])
+    def test_submit_raises_unexpected_resp(self, monkeypatch, response):
+        """Test that the qe_submit method raises an error if the workflow id
+        could not be obtained."""
+
+        unexp_resp_msg = "Received an unexpected response after submitting workflow."
+        with monkeypatch.context() as m:
+            # Disable submitting to the Orquestra platform by mocking Popen
+            m.setattr(subprocess, "Popen", lambda *args, **kwargs: MockPopen(response))
+            m.setattr(os, "remove", lambda *args, **kwargs: None)
+
+            with pytest.raises(ValueError, match=unexp_resp_msg):
+                workflow_id = qe_submit("some_filename")
+
+    def test_workflow_results(self, monkeypatch):
+        """Test that the workflow_results function passes the correct option to
+        qe_get."""
+
+        mock_results = "12345"
+
+        def mock_qe_get(wf_id, option=None):
+            if option == "workflowresult":
+                return mock_results
+
+        with monkeypatch.context() as m:
+            m.setattr(pennylane_orquestra.cli_actions, "qe_get", mock_qe_get)
+            res = pennylane_orquestra.cli_actions.workflow_results("Some workflow ID")
+            assert res == mock_results
+
+    def test_write_workflow_file(self, tmpdir, monkeypatch):
+        """Test that filling in the workflow template for getting expectation
+        values produces a valid yaml."""
+        backend_component = "qe-forest"
+
+        # Fill in workflow template
+        workflow = gw.gen_expval_workflow(
+            backend_component, backend_specs_default, qasm_circuit_default, operator_string_default
+        )
+
+        file_name = "test_workflow.yaml"
+        with monkeypatch.context() as m:
+            m.setattr(pennylane_orquestra.cli_actions, "user_data_dir", lambda *args: tmpdir)
+            write_workflow_file(file_name, workflow)
+
+        with open(tmpdir.join(file_name)) as file:
+            loaded_yaml = yaml.load(file, Loader=yaml.FullLoader)
+
+        assert workflow == loaded_yaml
+
+    @pytest.mark.parametrize("res_msg", ["Some message2", "First line\n Second "])
+    def test_loop_until_finished_raises(self, res_msg, monkeypatch):
+        """Check that certain errors are raised and handled correctly by the
+        loop_until_finished function."""
+        with monkeypatch.context() as m:
+            m.setattr(
+                pennylane_orquestra.cli_actions, "workflow_details", lambda *args: "Some message1"
+            )
+            m.setattr(pennylane_orquestra.cli_actions, "workflow_results", lambda *args: res_msg)
+
+            # Check that indexing into the message raises an IndexError
+            # (this shows that it will be handled internally)
+            with pytest.raises(IndexError, match="list index out of range"):
+                location = res_msg[1].split()[1]
+
+            # Check that looping eventually times out
+            with pytest.raises(TimeoutError, match="were not obtained after"):
+                loop_until_finished("Some ID", timeout=1)
+
+    def test_loop_raises_workflow_fail(self, monkeypatch):
+        """Check that an error is raised if the workflow exeuction failed."""
+        with monkeypatch.context() as m:
+            status = "Status:              Failed\n"
+            result_message = "Some message2"
+
+            m.setattr(pennylane_orquestra.cli_actions, "workflow_details", lambda *args: status)
+            m.setattr(
+                pennylane_orquestra.cli_actions,
+                "workflow_results",
+                lambda *args: result_message,
+            )
+
+            # Check that looping raises an error if the workflow details
+            # contain a failed status
+            with pytest.raises(
+                ValueError, match=f"Something went wrong with executing the workflow. {status}"
+            ):
+                loop_until_finished("Some ID", timeout=1)
+
+    def test_valid_url(self, monkeypatch, tmpdir):
+        """Test that when receiving a valid url, data will be decoded and
+        returned."""
+        decoded_data = {"res": "Decoded Data"}
+        test_file = os.path.join(tmpdir, "workflow_result.json")
+        test_tar = os.path.join(tmpdir, "test.tgz")
+
+        with open(test_file, "w") as outfile:
+            json.dump(decoded_data, outfile)
+
+        tar = tarfile.open(test_tar, mode="w:gz")
+        tar.add(test_tar)
+        tar.close()
+
+        # Change to the test directory
+        os.chdir(tmpdir)
+        with monkeypatch.context() as m:
+            status = "Status:              Failed\n"
+            result_message = ["Some message2", "Some location"]
+
+            m.setattr(
+                pennylane_orquestra.cli_actions, "workflow_results", lambda *args: result_message
+            )
+            m.setattr(urllib.request, "urlopen", lambda arg: arg)
+            m.setattr(urllib.request, "urlretrieve", lambda *args, **kwargs: (test_tar,))
+            assert loop_until_finished("Some ID", timeout=1) == decoded_data
+
+    def test_invalid_url_loop_till_timeout(self, monkeypatch):
+        """Test that when receiving an invalid url, looping continues until the
+        timeout."""
+        decoded_data = "Decoded Data"
+
+        class MockDecodableObj:
+            """A mock class that can be decoded."""
+
+            def decode(self):
+                return decoded_data
+
+        class MockURL:
+            """A mock class for URLs that can serve as a context manager."""
+
+            def __enter__(self):
+                pass
+
+            def __exit__(self, *args):
+                pass
+
+            def read(self):
+                return MockDecodableObj()
+
+        def raise_urllib_error(*args):
+            """Auxiliary function that raises a URLError."""
+            raise urllib.error.URLError("Test error due to an incorrect URL.")
+
+        with monkeypatch.context() as m:
+            status = "Status:              Failed\n"
+            result_message = ["Some message2", "Some location"]
+
+            m.setattr(
+                pennylane_orquestra.cli_actions, "workflow_results", lambda *args: result_message
+            )
+            m.setattr(urllib.request, "urlopen", raise_urllib_error)
+
+            with pytest.raises(TimeoutError, match="were not obtained after"):
+                loop_until_finished("Some ID", timeout=1)

--- a/tests/test_cli_actions.py
+++ b/tests/test_cli_actions.py
@@ -68,7 +68,7 @@ class TestCLIFunctions:
 
         mock_results = "12345"
 
-        def mock_qe_get(option=None):
+        def mock_qe_get(*args, option=None):
             if option == "workflowresult":
                 return mock_results
 

--- a/tests/test_cli_actions.py
+++ b/tests/test_cli_actions.py
@@ -37,8 +37,8 @@ class TestCLIFunctions:
     """Test functions for CLI actions work as expected."""
 
     def test_submit_raises_no_success(self, monkeypatch):
-        """Test that the qe_submit method raises an error if not a successful
-        message was received."""
+        """Test that the qe_submit method raises an error if a success
+        message was not received."""
 
         no_success_msg = "Not a success message."
         with monkeypatch.context() as m:

--- a/tests/test_cli_actions.py
+++ b/tests/test_cli_actions.py
@@ -162,7 +162,7 @@ class TestCLIFunctions:
             assert loop_until_finished("Some ID", timeout=1) == decoded_data
 
     # Expected to fail if qe is unavailable
-    @pytest.mark.xfail(raises=RuntimeError)
+    @pytest.mark.xfail(raises=FileNotFoundError)
     def test_invalid_url_loop_till_timeout(self, monkeypatch):
         """Test that when receiving an invalid url, looping continues until the
         timeout."""

--- a/tests/test_cli_actions.py
+++ b/tests/test_cli_actions.py
@@ -1,3 +1,17 @@
+# Copyright 2020 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Unit tests for the ```cli_actions`` module, without sending any requests to
 Orquestra.


### PR DESCRIPTION
**Context**

At the moment, submitting workflows as jobs to Orquestra can be done only via the Quantum Engine command line tool.

**Changes**

This PR adds functions that make `qe` CLI calls for submitting workflows and getting their details & results.

These functions are specifically tailored to the Orquestra API v1.0.0 version and can be sensitive in their functioning. The aim was to keep dependencies on the responses sent by Orquestra to a minimum.

**Benefits**

The Orquestra platform is available from Python scripts.

**Drawbacks**
Change in the responses sent by Orquestra can lead to breaking changes.