### PR TITLE
Updates IBMQ no token test

### DIFF
--- a/pennylane_orquestra/ibmq_device.py
+++ b/pennylane_orquestra/ibmq_device.py
@@ -57,7 +57,9 @@ class QeIBMQDevice(OrquestraDevice):
 
         if self._token is None:
             raise ValueError(
-                "Please pass a valid IBMQX token to the device using the 'ibmqx_token' argument."
+                "Please pass a valid IBMQX token to the device using the "
+                "'ibmqx_token' argument or by specifying the IBMQX_TOKEN "
+                "environment variable."
             )
 
         if kwargs.get("analytic", None):

--- a/tests/test_orquestra_device.py
+++ b/tests/test_orquestra_device.py
@@ -89,9 +89,10 @@ class TestBaseDevice:
 
         assert not dev.analytic
 
-    def test_ibmq_no_token_error(self):
+    def test_ibmq_no_token_error(self, monkeypatch):
         """Test that an error is raised when using the IBMQDevice without any
         tokens specified."""
+        monkeypatch.delenv("IBMQX_TOKEN", raising=False)
         with pytest.raises(ValueError, match="Please pass a valid IBMQX token"):
             dev = qml.device("orquestra.ibmq", wires=2, analytic=False)
 


### PR DESCRIPTION
1. Updates the IBMQ device no token test to explicitly exclude any environment variables during the test case.
2. Expands the error message raised when no token was found.