### PR TITLE
Fix batch execute single tape

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
           - {python-version: 3.7}
           - {python-version: 3.8}
           - {python-version: 3.9}
-          - {python-version: 3.10}
+          - {python-version: '3.10'}
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,8 @@ jobs:
         config:
           - {python-version: 3.7}
           - {python-version: 3.8}
+          - {python-version: 3.9}
+          - {python-version: 3.10}
 
     steps:
       - name: Cancel Previous Runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.16.0-dev0
+# Release 0.20.0-dev0
 
 ### New features since last release
 
@@ -10,9 +10,15 @@
 
 ### Bug fixes
 
+* Changes the `batch_execute` method to support executing single tapes as per
+  PennyLane v0.20.0 where batch execution is the default for a QNode.
+  [(#XX)](https://github.com/XanaduAI/pennylane-orquestra/pull/XX)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Antal Száva
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 * Changes the `batch_execute` method to support executing single tapes as per
   PennyLane v0.20.0 where batch execution is the default for a QNode.
-  [(#XX)](https://github.com/XanaduAI/pennylane-orquestra/pull/XX)
+  [(#22)](https://github.com/XanaduAI/pennylane-orquestra/pull/22)
 
 ### Contributors
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 docutils==0.16
 sphinxcontrib-bibtex
 pygments-github-lexers
-pennylane
+git+https://github.com/PennyLaneAI/pennylane.git
 sphinx-automodapi

--- a/pennylane_orquestra/orquestra_device.py
+++ b/pennylane_orquestra/orquestra_device.py
@@ -21,7 +21,7 @@ import json
 import re
 import uuid
 
-from pennylane import QubitDevice
+from pennylane import QubitDevice, matrix
 from pennylane.operation import Expectation, Tensor
 from pennylane.ops import Identity
 from pennylane.utils import decompose_hamiltonian
@@ -360,7 +360,7 @@ class OrquestraDevice(QubitDevice, abc.ABC):
             # Decompose the matrix of the observable
             # This removes information about the wire labels used and
             # consecutive integer wires are used
-            coeffs, obs_list = decompose_hamiltonian(qml.matrix(original_observable))
+            coeffs, obs_list = decompose_hamiltonian(matrix(original_observable))
 
             for idx in range(len(obs_list)):
                 obs = obs_list[idx]

--- a/pennylane_orquestra/orquestra_device.py
+++ b/pennylane_orquestra/orquestra_device.py
@@ -360,7 +360,7 @@ class OrquestraDevice(QubitDevice, abc.ABC):
             # Decompose the matrix of the observable
             # This removes information about the wire labels used and
             # consecutive integer wires are used
-            coeffs, obs_list = decompose_hamiltonian(original_observable.matrix)
+            coeffs, obs_list = decompose_hamiltonian(qml.matrix(original_observable))
 
             for idx in range(len(obs_list)):
                 obs = obs_list[idx]

--- a/pennylane_orquestra/orquestra_device.py
+++ b/pennylane_orquestra/orquestra_device.py
@@ -28,12 +28,9 @@ from pennylane.utils import decompose_hamiltonian
 from pennylane.wires import Wires
 
 from pennylane_orquestra._version import __version__
-from pennylane_orquestra.cli_actions import (
-    loop_until_finished,
-    qe_submit,
-    write_workflow_file,
-    workflow_details,
-)
+from pennylane_orquestra.cli_actions import (loop_until_finished, qe_submit,
+                                             workflow_details,
+                                             write_workflow_file)
 from pennylane_orquestra.gen_workflow import gen_expval_workflow
 from pennylane_orquestra.utils import _terms_to_qubit_operator_string
 

--- a/pennylane_orquestra/orquestra_device.py
+++ b/pennylane_orquestra/orquestra_device.py
@@ -28,9 +28,12 @@ from pennylane.utils import decompose_hamiltonian
 from pennylane.wires import Wires
 
 from pennylane_orquestra._version import __version__
-from pennylane_orquestra.cli_actions import (loop_until_finished, qe_submit,
-                                             workflow_details,
-                                             write_workflow_file)
+from pennylane_orquestra.cli_actions import (
+    loop_until_finished,
+    qe_submit,
+    workflow_details,
+    write_workflow_file,
+)
 from pennylane_orquestra.gen_workflow import gen_expval_workflow
 from pennylane_orquestra.utils import _terms_to_qubit_operator_string
 

--- a/pennylane_orquestra/orquestra_device.py
+++ b/pennylane_orquestra/orquestra_device.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Xanadu Quantum Technologies Inc.
+# Copyright 2020-2021 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -499,6 +499,10 @@ class OrquestraDevice(QubitDevice, abc.ABC):
         return results
 
     def batch_execute(self, circuits, **kwargs):
+
+        if len(circuits) == 1:
+            return [self.execute(circuits[0], **kwargs)]
+
         results = []
         idx = 0
         file_prefix = f"{str(uuid.uuid4())}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pennylane>=0.15
+git+https://github.com/PennyLaneAI/pennylane.git
 pyyaml

--- a/steps/expval.py
+++ b/steps/expval.py
@@ -25,7 +25,7 @@ import numpy as np
 from openfermion import IsingOperator, QubitOperator
 from qiskit import QuantumCircuit
 
-from zquantum.core.circuits import Circuit
+from zquantum.core import circuits
 from zquantum.core.measurement import expectation_values_to_real
 from zquantum.core.utils import create_object, save_list
 
@@ -56,6 +56,8 @@ def run_circuit_and_get_expval(
             or ``openfermion.IsingOperator`` representation
     """
     backend_specs = json.loads(backend_specs)
+    n_samples = backend_specs.get("n_samples", None)
+
     operators = json.loads(operators)
 
     backend = create_object(backend_specs)
@@ -65,7 +67,7 @@ def run_circuit_and_get_expval(
 
     # 2. Create operators
     ops = []
-    if backend.n_samples is not None:
+    if n_samples is not None:
         # Operators for Backend/Simulator in sampling mode
         for op in operators:
             ops.append(IsingOperator(op))
@@ -93,16 +95,16 @@ def run_circuit_and_get_expval(
             # Apply the identity
             qc.id(qubit)
 
-    # Convert to zquantum.core.circuit.Circuit
-    circuit = Circuit(qc)
+    # Convert to zquantum.core.circuits.Circuit
+    circuit = circuits.import_from_qiskit(qc)
 
     # 3. Expval
-    results = _get_expval(backend, circuit, ops)
+    results = _get_expval(backend, circuit, ops, n_samples)
 
     save_list(results, "expval.json")
 
 
-def _get_expval(backend, circuit, ops):
+def _get_expval(backend, circuit, ops, n_samples):
     """Auxiliary function to get the expectation value of a list of operators
     given a quantum circuit and a quantum backend.
 
@@ -114,7 +116,7 @@ def _get_expval(backend, circuit, ops):
 
     Args:
         backend (QuantumBackend): the Orquestra quantum backend to use
-        circuit (zquantum.core.circuit.Circuit): the circuit represented as an
+        circuit (zquantum.core.circuits.Circuit): the circuit represented as an
             OpenQASM 2.0 program
         operators (list): a list of operators as ``openfermion.QubitOperator``
             or ``openfermion.IsingOperator`` objects
@@ -124,8 +126,8 @@ def _get_expval(backend, circuit, ops):
     """
     results = []
 
-    if backend.n_samples is not None:
-        measurements = backend.run_circuit_and_measure(circuit)
+    if n_samples is not None:
+        measurements = backend.run_circuit_and_measure(circuit, n_samples)
 
         # Iterating through the operators specified e.g., [IsingOperator("[Z0]
         # + [Z1]"), IsingOperator("[Z1]")] to post-process the measurements

--- a/steps/expval.py
+++ b/steps/expval.py
@@ -57,7 +57,7 @@ def run_circuit_and_get_expval(
             or ``openfermion.IsingOperator`` representation
     """
     backend_specs = json.loads(backend_specs)
-    n_samples = backend_specs.get("n_samples", None)
+    n_samples = backend_specs.pop("n_samples", None)
 
     operators = json.loads(operators)
 

--- a/steps/expval.py
+++ b/steps/expval.py
@@ -28,6 +28,7 @@ from qiskit import QuantumCircuit
 from zquantum.core import circuits
 from zquantum.core.measurement import expectation_values_to_real
 from zquantum.core.utils import create_object, save_list
+from qeqiskit.conversions import import_from_qiskit
 
 
 def run_circuit_and_get_expval(
@@ -96,7 +97,7 @@ def run_circuit_and_get_expval(
             qc.id(qubit)
 
     # Convert to zquantum.core.circuits.Circuit
-    circuit = circuits.import_from_qiskit(qc)
+    circuit = import_from_qiskit(qc)
 
     # 3. Expval
     results = _get_expval(backend, circuit, ops, n_samples)

--- a/steps/expval.py
+++ b/steps/expval.py
@@ -25,7 +25,7 @@ import numpy as np
 from openfermion import IsingOperator, QubitOperator
 from qiskit import QuantumCircuit
 
-from zquantum.core.circuit import Circuit
+from zquantum.core.circuits import Circuit
 from zquantum.core.measurement import expectation_values_to_real
 from zquantum.core.utils import create_object, save_list
 

--- a/tests/test_orquestra_device.py
+++ b/tests/test_orquestra_device.py
@@ -329,10 +329,10 @@ obs_decomposed_wires_check = [
         "0.4999999999999999 [X2 X1] + 0.4999999999999999 [X2 Z1] + 0.4999999999999999 [Z2 X1] + 0.4999999999999999 [Z2 Z1]",
     ),
     (
-        qml.Hermitian((qml.PauliY(1) @ qml.PauliX(0) @ qml.PauliZ(2)).matrix, wires=[1, 0, 2]),
+        qml.Hermitian(qml.matrix(qml.PauliY(1) @ qml.PauliX(0) @ qml.PauliZ(2)), wires=[1, 0, 2]),
         "1.0 [Y1 X0 Z2]",
     ),
-    (qml.PauliY(2) @ qml.Hermitian((qml.PauliX(1)).matrix, wires=[1]), "1.0 [Y2 X1]"),
+    (qml.PauliY(2) @ qml.Hermitian(qml.matrix(qml.PauliX(1)), wires=[1]), "1.0 [Y2 X1]"),
 ]
 
 


### PR DESCRIPTION
**Changes**
* Changes the `batch_execute` method to support executing single tapes as per
  PennyLane v0.20.0 where batch execution is the default for a QNode.

Also, fixes issues that came from updates in PennyLane and in the Z-Quantum libraries:
* Fixed an import to use `from zquantum.core import circuits`;
* Pulls the `import_from_qiskit` function from `qeqiskit.conversions`;
* Updates the logic to pass the `n_samples` to the methods being used from z-quantum-core rather than using it while creating a backend (`create_object`);
* Updates to using the new `qml.matrix` top-level function.

Also added Python 3.9 and Python 3.10 runners.