### PR TITLE
Pin to PennyLane version `>=v0.22`

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 docutils==0.16
 sphinxcontrib-bibtex
 pygments-github-lexers
-git+https://github.com/PennyLaneAI/pennylane.git
+pennylane>=0.22
 sphinx-automodapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/PennyLaneAI/pennylane.git
+pennylane>=0.22
 pyyaml


### PR DESCRIPTION
The PennyLane-Orquestra plugin uses the `qml.matrix` pipeline introduced in PennyLane v0.22.0. Therefore the PennyLane requirement of the plugin has been increased.

*Note:* the checks in this PR will be failing until v0.22.0 of PennyLane has been released.