### PR TITLE
Switch to GA4

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -64,7 +64,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'PennyLane-Orquestra'
-copyright = "2022, Xanadu Quantum Technologies Inc."
+copyright = "2023, Xanadu Quantum Technologies Inc."
 author = 'Carsten Blank, Xanadu Inc.'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -291,7 +291,7 @@ html_theme_options = {
     ],
     "toc_overview": True,
     "navbar_active_link": 3,
-    "google_analytics_tracking_id": "UA-130507810-1"
+    "google_analytics_tracking_id": "G-C480Z9JL0D"
 }
 
 edit_on_github_project = 'PennyLaneAI/pennylane-orquestra'

--- a/pennylane_orquestra/cli_actions.py
+++ b/pennylane_orquestra/cli_actions.py
@@ -194,7 +194,6 @@ def loop_until_finished(workflow_id, timeout=600):
             )
 
         if tries % 20 == 0:
-
             # Check if the status shows that the workflow failed, after a
             # certain number of tries
             status = workflow_details(workflow_id)
@@ -214,7 +213,6 @@ def loop_until_finished(workflow_id, timeout=600):
 
         # 2. Check that the location is a valid URL
         try:
-
             # We expect that this fails if an invalid URL location was outputted
             urllib.request.urlopen(location)
 

--- a/pennylane_orquestra/ibmq_device.py
+++ b/pennylane_orquestra/ibmq_device.py
@@ -50,7 +50,6 @@ class QeIBMQDevice(OrquestraDevice):
     qe_function_name = "QiskitBackend"
 
     def __init__(self, wires, shots=8192, backend="ibmq_qasm_simulator", **kwargs):
-
         self._token = kwargs.get("ibmqx_token", None) or os.getenv("IBMQX_TOKEN")
 
         if self._token is None:

--- a/pennylane_orquestra/orquestra_device.py
+++ b/pennylane_orquestra/orquestra_device.py
@@ -499,7 +499,6 @@ class OrquestraDevice(QubitDevice, abc.ABC):
         return results
 
     def batch_execute(self, circuits, **kwargs):
-
         if len(circuits) == 1:
             return [self.execute(circuits[0], **kwargs)]
 

--- a/pennylane_orquestra/utils.py
+++ b/pennylane_orquestra/utils.py
@@ -85,7 +85,6 @@ def _process_wires(wires, n_wires=None):
         wires = Wires(wires[:n_wires])
 
     elif isinstance(wires, dict):
-
         if all([isinstance(w, int) for w in wires.keys()]):
             # Assuming keys are taken from consecutive int wires. Allows for partial mapping.
             n_wires = max(wires) + 1
@@ -163,7 +162,6 @@ def _terms_to_qubit_operator_string(coeffs, ops, wires=None):
 
     q_op = []
     for coeff, op in zip(coeffs, ops):
-
         extra_obsvbs = set(op.name) - {"PauliX", "PauliY", "PauliZ", "Identity"}
         if extra_obsvbs != set():
             raise ValueError(


### PR DESCRIPTION
Google is deprecating Universal Analytics on July 1st. This PR replaces that tag with the newer GA4 tag.