### PR TITLE
use correct pypi upload action version, add release automation workflows

### DIFF
--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -1,0 +1,30 @@
+name: Automated Release Version Bumps
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  post_release_version_bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Run post-release version bump
+        uses: PennyLaneAI/automation/version_bump_action@main
+        with:
+          version_path: "./pennylane_orquestra/_version.py"
+          changelog_path: "./CHANGELOG.md"
+          release_status: "post_release"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: post release version bump
+          title: Version Bump
+          body: updated changelog and _version.py
+          branch: post-release-version-bump
+          reviewers: mudit2812
+          base: master

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -1,0 +1,29 @@
+name: Manually Triggered Version Bumps
+
+on:
+  workflow_dispatch:
+
+jobs:
+  pre_release_version_bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Run pre-release version bump
+        uses: PennyLaneAI/automation/version_bump_action@main
+        with:
+          version_path: "./pennylane_orquestra/_version.py"
+          changelog_path: "./CHANGELOG.md"
+          release_status: "pre_release"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: pre release version bump
+          title: Version Bump
+          body: updated changelog and _version.py
+          branch: pre-release-version-bump
+          reviewers: mudit2812
+          base: master

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           python -m pytest tests -k 'not e2e' --tb=native
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI }}


### PR DESCRIPTION
As instructions say [here](https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-) (a warning came up when uploading various things for 0.31)

the workflow files are copy-pasted, and I've set @mudit2812 as owner for this plugin.