### PR TITLE
Add support `StatePrep`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Add support for `qml.StatePrep` as a state preparation operation.
   [(#39)](https://github.com/PennyLaneAI/pennylane-orquestra/pull/39)
 
-### Contributors
+### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release 0.32.0
 
-### Improvements
+### Improvements 🛠
 
 * Add support for `qml.StatePrep` as a state preparation operation.
   [(#39)](https://github.com/PennyLaneAI/pennylane-orquestra/pull/39)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# Release 0.32.0
+
+### Improvements
+
+* Add support for `qml.StatePrep` as a state preparation operation.
+  [(#39)](https://github.com/PennyLaneAI/pennylane-orquestra/pull/39)
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+Jay Soni
+
+---
+
 # Release 0.28.0
 
 ### Bug fixes 

--- a/pennylane_orquestra/orquestra_device.py
+++ b/pennylane_orquestra/orquestra_device.py
@@ -105,6 +105,7 @@ class OrquestraDevice(QubitDevice, abc.ABC):
         "PauliZ",
         "PhaseShift",
         "QubitStateVector",
+        "StatePrep"
         "RX",
         "RY",
         "RZ",

--- a/pennylane_orquestra/orquestra_device.py
+++ b/pennylane_orquestra/orquestra_device.py
@@ -105,7 +105,7 @@ class OrquestraDevice(QubitDevice, abc.ABC):
         "PauliZ",
         "PhaseShift",
         "QubitStateVector",
-        "StatePrep"
+        "StatePrep",
         "RX",
         "RY",
         "RZ",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/PennyLaneAI/pennylane.git
+pennylane>=0.28
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pennylane>=0.28
+git+https://github.com/PennyLaneAI/pennylane.git
 pyyaml


### PR DESCRIPTION
Following the work [here](https://github.com/PennyLaneAI/pennylane/pull/4450/), we make sure that the pennylane-orquestra plugin supports both operators and defaults to using `StatePrep` where appropriate until it is deprecated.