### PR TITLE
change base from master to main in version bump action

### DIFF
--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -27,4 +27,4 @@ jobs:
           body: updated changelog and _version.py
           branch: post-release-version-bump
           reviewers: mudit2812
-          base: master
+          base: main

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -26,4 +26,4 @@ jobs:
           body: updated changelog and _version.py
           branch: pre-release-version-bump
           reviewers: mudit2812
-          base: master
+          base: main


### PR DESCRIPTION
the action [failed](https://github.com/PennyLaneAI/pennylane-orquestra/actions/runs/5957262425/job/16159633355) because of this. pls approve so i can bump the version auto-manually