### PR TITLE
Update Sphinx-action version to tag

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: PennyLaneAI/sphinx-action@master
+    - uses: PennyLaneAI/sphinx-action@3.9
       with:
         docs-folder: "doc/"
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: PennyLaneAI/sphinx-action@3.9
+    - uses: PennyLaneAI/sphinx-action@master
       with:
         docs-folder: "doc/"
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,6 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
   apt_packages:
     - graphviz

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath('.')), 'doc'))
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.6'
+needs_sphinx = '8.1'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,10 +3,10 @@ sphinx==8.1
 docutils==0.16
 sphinxcontrib-applehelp==2.0.0
 sphinxcontrib-bibtex==2.4.2
-sphinxcontrib-devhelp==1.0.6
-sphinxcontrib-htmlhelp==2.0.1
-sphinxcontrib-qthelp==1.0.3
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-devhelp==2.0.0
+sphinxcontrib-htmlhelp==2.1.0
+sphinxcontrib-qthelp==2.0.0
+sphinxcontrib-serializinghtml==2.0.0
 pygments-github-lexers==0.0.5
 pennylane>=0.22,<0.34
 sphinx-automodapi==0.14.1

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,7 +3,7 @@ sphinx==8.1
 docutils==0.16
 sphinxcontrib-applehelp==2.0.0
 sphinxcontrib-bibtex==2.4.2
-sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-devhelp==1.0.6
 sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
 jinja2==3.0.3
 sphinx==8.1 
 docutils==0.16
-sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-applehelp==2.0.0
 sphinxcontrib-bibtex==2.4.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.1

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,5 @@
 jinja2==3.0.3
-sphinx~=3.5.0; python_version < "3.10"
-sphinx==4.2; python_version == "3.10"
+sphinx==8.1 
 docutils==0.16
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-bibtex==2.4.2


### PR DESCRIPTION
docs.yml currently uses sphinx-action to run the documentation checks. Sphinx-action is being upgraded to python 3.10 which is incompatible with the existing docs.yml workflow. This PR will update docs.yml to use a version of sphinx-action that is pegged to python 3.9 and a lower version of sphinx. 